### PR TITLE
feat: TraceID 移入 Pipeline 内置中间件 + 清理无用配置

### DIFF
--- a/src/FLEA.php
+++ b/src/FLEA.php
@@ -684,15 +684,7 @@ class FLEA
         // 初始化 View 渲染器配置
         self::initViewRenderer();
 
-        define('RESPONSE_CHARSET', self::getAppInf('responseCharset'));
         define('DATABASE_CHARSET', self::getAppInf('databaseCharset'));
-
-        if (self::getAppInf('autoResponseHeader')) {
-            header('Content-Type: text/html; charset=' . self::getAppInf('responseCharset'));
-        }
-
-        // 输出 traceId 响应头（在任何响应体之前）
-        header('X-Trace-Id: ' . \FLEA\Context\TraceContext::getFullTraceId());
     }
 
     /**

--- a/src/FLEA/Config/Defaults.php
+++ b/src/FLEA/Config/Defaults.php
@@ -125,8 +125,6 @@ class Defaults
             'errorMessagesFile' => '',
 
             // 响应
-            'responseCharset' => 'UTF-8',
-            'autoResponseHeader' => true,
             'forceJsonResponse' => false,
 
             // 调度器

--- a/src/FLEA/Middleware/Pipeline.php
+++ b/src/FLEA/Middleware/Pipeline.php
@@ -80,14 +80,21 @@ class Pipeline
      * 使用 array_reduce 从后向前构建中间件调用链，
      * 形成洋葱模型嵌套结构。
      *
+     * 框架内置 TraceIdMiddleware 自动作为最外层，
+     * 确保 X-Trace-Id 响应头在任何情况下都能输出。
+     *
      * @param callable $destination 最终要执行的目标（控制器/闭包）
      *
      * @return void
      */
     public function run(callable $destination): void
     {
+        // 框架内置中间件（最外层）
+        $builtIn = [new TraceIdMiddleware()];
+        $all = array_merge($builtIn, $this->middlewares);
+
         $pipeline = array_reduce(
-            array_reverse($this->middlewares),
+            array_reverse($all),
             fn(callable $carry, MiddlewareInterface $mw) => fn() => $mw->handle($carry),
             $destination
         );

--- a/src/FLEA/Middleware/TraceIdMiddleware.php
+++ b/src/FLEA/Middleware/TraceIdMiddleware.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace FLEA\Middleware;
+
+/**
+ * 链路追踪 ID 中间件
+ *
+ * 框架内置，自动作为 Pipeline 最外层中间件。
+ * 在每个请求中输出 X-Trace-Id 响应头。
+ *
+ * @package FLEA
+ * @author toohamster
+ * @version 2.3.0
+ */
+class TraceIdMiddleware implements MiddlewareInterface
+{
+    /**
+     * 处理请求
+     *
+     * @param callable $next 下一个中间件或请求处理器
+     *
+     * @return void
+     */
+    public function handle(callable $next): void
+    {
+        // 前置设置 TraceID header，确保任何中间件短路都不会丢失
+        \FLEA\Response::current()->withHeader(
+            'X-Trace-Id',
+            \FLEA\Context\TraceContext::getFullTraceId()
+        );
+
+        $next();
+    }
+}


### PR DESCRIPTION
## 概要

v2.3.0 发布后的后续优化。

## 主要改动

- **新增 `TraceIdMiddleware`**：框架内置最外层中间件，通过 Response 门面输出 X-Trace-Id
- **Pipeline::run()** 自动将 TraceIdMiddleware 作为最外层，用户无感知
- **FLEA::init()** 移除直接 `header('X-Trace-Id')` 输出
- **删除 `autoResponseHeader` 配置项**（各 View 已自带 getContentType()）
- **删除 `responseCharset` 配置和 `RESPONSE_CHARSET` 常量**（框架统一 UTF-8）

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>